### PR TITLE
Use absolute URLs for link embed images

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,10 +4,11 @@ description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "/" 
-url: "/portfolio-template" 
+baseurl: "/portfolio-template" 
+url: "https://jkmartindale.github.io" 
 twitter_username: mlhacks
 github_username:  mlh-fellowship
+social_image: "./assets/img/social-link.jpg" 
 
 sass:
   sass_dir: _sass

--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,10 @@ description: >- # this means to ignore newlines until "baseurl:"
   Write an awesome description for your new site here. You can edit this
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
-baseurl: "/portfolio-template" 
-url: "https://jkmartindale.github.io" 
+# Root directory for your portfolio. On GitHub Pages, this is the name of your repository.
+baseurl: "/portfolio-template"
+# Protocol + hostname for your portfolio. On GitHub Pages, this is https://yourusername.github.io
+url: "https://mlh-fellowship.github.io" 
 twitter_username: mlhacks
 github_username:  mlh-fellowship
 social_image: "./assets/img/social-link.jpg" 

--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,6 @@ baseurl: "/"
 url: "/portfolio-template" 
 twitter_username: mlhacks
 github_username:  mlh-fellowship
-cover: "./assets/img/social-link.jpg" 
 
 sass:
   sass_dir: _sass

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -46,7 +46,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css"
         integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
 
-    <link lang='sass' rel="stylesheet" href="{{ site.url }}/assets/css/main.css">
-    <link rel='icon' href='{{ site.url }}/assets/img/favicon.ico' type='image/x-icon' />
+    <link lang="sass" rel="stylesheet" href="{{ 'assets/css/main.css' | absolute_url }}">
+    <link rel="icon" href="{{ '/assets/img/favicon.ico' | absolute_url }}" type="image/x-icon" />
     <title>{{ site.title }}</title>
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,12 +7,12 @@
     <meta name="title" content="{{ site.title }}">
     <meta name="description" content="{{ site.title }}">
 
+    {% capture social_image %}{{site.social_image | absolute_url }}{% endcapture %}
     <!-- Open Graph / Facebook -->
-    {% capture social_image %}{{site.github.url}}/assets/img/social-link.jpg{% endcapture %}
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ page.url}}">
     <meta property="og:title" content="{{ site.title }}">
-    <meta property="og:description" content="{{ site.title }}">
+    <meta property="og:description" content="{{ site.description }}">
     <meta property="og:image:secure_url" content="{{ social_image }}">
     <meta property="og:image:secure" content="{{ social_image }}">
     <meta property="og:image:url" content="{{ social_image }}">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,21 +8,22 @@
     <meta name="description" content="{{ site.title }}">
 
     <!-- Open Graph / Facebook -->
+    {% capture social_image %}{{site.github.url}}/assets/img/social-link.jpg{% endcapture %}
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ page.url}}">
     <meta property="og:title" content="{{ site.title }}">
     <meta property="og:description" content="{{ site.title }}">
-    <meta property="og:image:secure_url" content="{{ site.cover }}">
-    <meta property="og:image:secure" content="{{ site.cover }}">
-    <meta property="og:image:url" content="{{ site.cover }}">
-    <meta property="og:image" content="{{ site.cover }}">
+    <meta property="og:image:secure_url" content="{{ social_image }}">
+    <meta property="og:image:secure" content="{{ social_image }}">
+    <meta property="og:image:url" content="{{ social_image }}">
+    <meta property="og:image" content="{{ social_image }}">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="{{ page.url}}">
     <meta property="twitter:title" content="{{ site.title }}">
     <meta property="twitter:description" content="{{ site.description }}">
-    <meta property="twitter:image" content="{{ site.cover }}">
+    <meta property="twitter:image" content="{{ social_image }}">
     <meta name='twitter:site' content='@{{ site.twitter_username }}' />
     <meta name='twitter:creator' content='@{{ site.twitter_username }}' />
 


### PR DESCRIPTION
It looks like Open Graph and Twitter Cards want to see absolute instead of relative URLs.

Jekyll provides an `absolute_url` filter that basically appends `site.url` and `site.baseurl` to your string. Both were misconfigured in the upstream `_config.yml` file.