### PR TITLE
Fix absolute URLs for projects and navbar resume

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -3,7 +3,7 @@
         <a href="{{ '/' | relative_url }}">
             <div class="nav-logo">
                 <img src="./assets/img/logo.svg" />
-                <a class="nav-link" href="{{ site.url }}/cv/resume.pdf">Resume</a>                
+                <a class="nav-link" href="{{ '/cv/resume.pdf' | absolute_url }}">Resume</a>                
             </div>
         </a>        
     </div>

--- a/_includes/projects.html
+++ b/_includes/projects.html
@@ -2,7 +2,7 @@
 <div class="card-container">
     {% for item in site.data.projects %}
     {% if item.page-name %}
-    <a href="{{ site.url }}/projects/{{ item.page-name }}">
+    <a href="{{ '/projects/' | append: item.page-name | absolute_url }}">
     {% else %}
     <a>
     {% endif %}


### PR DESCRIPTION
This change uses the `absolute_url` filter to properly prepend `site.url` and `site.baseurl`

Sorry for skipping the review process, this is to fix a small breaking change for our PR.